### PR TITLE
Поддержка кастомных полей с пробелами

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.2
+  - 2.2.2
 
 notifications:
   email: false

--- a/lib/amorail.rb
+++ b/lib/amorail.rb
@@ -1,3 +1,6 @@
+require 'active_support/core_ext/hash/indifferent_access'
+require 'active_support/core_ext/object/to_query'
+
 require 'amorail/version'
 require 'amorail/config'
 require 'amorail/client'

--- a/lib/amorail/entity.rb
+++ b/lib/amorail/entity.rb
@@ -32,7 +32,7 @@ module Amorail
 
       def amo_property(name, options = {})
         properties[name] = options
-        attr_accessor(name)
+        attr_accessor(options.fetch(:method_name, name))
       end
 
       def attributes
@@ -87,6 +87,7 @@ module Amorail
       fields.each do |f|
         fname = f['code'] || f['name']
         next if fname.nil?
+        fname = self.class.properties.fetch(fname.downcase, {})[:method_name] || fname
         fname = "#{fname.downcase}="
         fval = f.fetch('values').first.fetch('value')
         send(fname, fval) if respond_to?(fname)

--- a/lib/amorail/entity/params.rb
+++ b/lib/amorail/entity/params.rb
@@ -20,7 +20,7 @@ module Amorail # :nodoc: all
 
       self.class.properties.each do |k, v|
         prop_id = props.send(k).id
-        prop_val = { value: send(k) }.merge(v)
+        prop_val = { value: send(v.fetch(:method_name, k)) }.merge(v)
         custom_fields << { id: prop_id, values: [prop_val] }
       end
 


### PR DESCRIPTION
Сейчас есть проблема с кастомными полями, в названии которых есть пробелы. Например:

```ruby
class MyContact < Amorail::Contact
  amo_property 'Тестовое поле'
end
```

Выдаст:

```shell
NameError: invalid attribute name `Тестовое поле'
from /Users/atipugin/Code/amorail/lib/amorail/entity.rb:35:in `attr_accessor'
```

Предлагаю добавить опцию для amo_property, которая позволяет задать название метода для поля. Например:

```ruby
amo_property 'Тестовое поле', method_name: :test_field
```

Так, в модели `Тестовое поле` будет доступно через метод `test_field`.