### PR TITLE
Fix "undefined method `AmoUnknownError'"

### DIFF
--- a/lib/amorail/client.rb
+++ b/lib/amorail/client.rb
@@ -92,7 +92,7 @@ module Amorail
       when 503
         fail ::Amorail::AmoServiceUnaviableError
       else
-        fail ::Amorail::AmoUnknownError(response.body)
+        fail ::Amorail::AmoUnknownError, response.body
       end
     end
   end


### PR DESCRIPTION
Hi @palkan,

thank you for the gem.

I got an error on first attempt
```
[1] pry(main)> Amorail.properties.tasks
NoMethodError: undefined method `AmoUnknownError' for Amorail:Module
from /Users/aleksey/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/amorail-0.3.0/lib/amorail/client.rb:95:in `handle_response'
```

I believe `.new` was missing here.