### PR TITLE
Add Note entity and Elementable behaviour

### DIFF
--- a/lib/amorail/entities/elementable.rb
+++ b/lib/amorail/entities/elementable.rb
@@ -1,11 +1,14 @@
 module Amorail
+  # Provides common functionallity for entities
+  # that can be attached to another objects.
   module Elementable
     extend ActiveSupport::Concern
 
     ELEMENT_TYPES = {
       contact: 1,
       lead:    2,
-      company: 3
+      company: 3,
+      task:    4
     }.freeze
 
     included do
@@ -13,8 +16,6 @@ module Amorail
 
       validates :element_id, :element_type,
                 presence: true
-
-      validates :element_type, inclusion: 1..3
     end
 
     ELEMENT_TYPES.each do |type, value|

--- a/lib/amorail/entities/elementable.rb
+++ b/lib/amorail/entities/elementable.rb
@@ -2,11 +2,11 @@ module Amorail
   module Elementable
     extend ActiveSupport::Concern
 
-    ELEMENT_TYPES = [
-      { name: 'contact', val: 1 },
-      { name: 'lead',    val: 2 },
-      { name: 'company', val: 3 }
-    ].freeze
+    ELEMENT_TYPES = {
+      contact: 1,
+      lead:    2,
+      company: 3
+    }.freeze
 
     included do
       amo_field :element_id, :element_type
@@ -17,19 +17,19 @@ module Amorail
       validates :element_type, inclusion: 1..3
     end
 
-    ELEMENT_TYPES.each do |type|
+    ELEMENT_TYPES.each do |type, value|
       class_eval <<-CODE, __FILE__, __LINE__ + 1
-        def #{type[:name]}=(val)
-          #{type[:name]}! if val
-        end
+        def #{type}=(val)                        # def contact=(val)
+          #{type}! if val                        #   contact! if val
+        end                                      # end
 
-        def #{type[:name]}?
-          self.element_type == #{type[:val]}
-        end
+        def #{type}?                             # def contact?
+          self.element_type == #{value}          #   self.element_type == 1
+        end                                      # end
 
-        def #{type[:name]}!
-          self.element_type = #{type[:val]}
-        end
+        def #{type}!                             # def contact!
+          self.element_type = #{value}           #   self.element_type = 1
+        end                                      # end
       CODE
     end
   end

--- a/lib/amorail/entities/elementable.rb
+++ b/lib/amorail/entities/elementable.rb
@@ -1,0 +1,36 @@
+module Amorail
+  module Elementable
+    extend ActiveSupport::Concern
+
+    ELEMENT_TYPES = [
+      { name: 'contact', val: 1 },
+      { name: 'lead',    val: 2 },
+      { name: 'company', val: 3 }
+    ].freeze
+
+    included do
+      amo_field :element_id, :element_type
+
+      validates :element_id, :element_type,
+                presence: true
+
+      validates :element_type, inclusion: 1..3
+    end
+
+    ELEMENT_TYPES.each do |type|
+      class_eval <<-CODE, __FILE__, __LINE__ + 1
+        def #{type[:name]}=(val)
+          #{type[:name]}! if val
+        end
+
+        def #{type[:name]}?
+          self.element_type == #{type[:val]}
+        end
+
+        def #{type[:name]}!
+          self.element_type = #{type[:val]}
+        end
+      CODE
+    end
+  end
+end

--- a/lib/amorail/entities/note.rb
+++ b/lib/amorail/entities/note.rb
@@ -1,0 +1,15 @@
+require 'amorail/entities/elementable'
+
+module Amorail
+  # AmoCRM note entity
+  class Note < Amorail::Entity
+    include Elementable
+
+    amo_names 'notes'
+
+    amo_field :note_type, :text
+
+    validates :note_type, :text,
+              presence: true
+  end
+end

--- a/lib/amorail/entities/note.rb
+++ b/lib/amorail/entities/note.rb
@@ -11,5 +11,7 @@ module Amorail
 
     validates :note_type, :text,
               presence: true
+
+    validates :element_type, inclusion: ELEMENT_TYPES.values
   end
 end

--- a/lib/amorail/entities/task.rb
+++ b/lib/amorail/entities/task.rb
@@ -1,32 +1,15 @@
+require 'amorail/entities/elementable'
+
 module Amorail
   # AmoCRM task entity
   class Task < Amorail::Entity
-    amo_names "tasks"
+    include Elementable
 
-    amo_field :element_id, :element_type, :text,
-              :task_type, complete_till: :timestamp
+    amo_names 'tasks'
 
-    validates :text, :element_id,
-              :element_type, :complete_till,
-              :task_type,
+    amo_field :task_type, :text, complete_till: :timestamp
+
+    validates :task_type, :text, :complete_till,
               presence: true
-
-    validates :element_type, inclusion: 1..2
-
-    [{ name: "contact", val: 1 }, { name: "lead", val: 2 }].each do |prop|
-      class_eval <<-CODE, __FILE__, __LINE__ + 1
-        def #{prop[:name]}=(val)
-          #{prop[:name]}! if val
-        end
-
-        def #{prop[:name]}?
-          self.element_type == #{prop[:val]}
-        end
-
-        def #{prop[:name]}!
-          self.element_type = #{prop[:val]}
-        end
-      CODE
-    end
   end
 end

--- a/lib/amorail/entities/task.rb
+++ b/lib/amorail/entities/task.rb
@@ -11,5 +11,8 @@ module Amorail
 
     validates :task_type, :text, :complete_till,
               presence: true
+
+    validates :element_type, inclusion:
+              ELEMENT_TYPES.reject { |type, _| type == :task }.values
   end
 end

--- a/spec/note_spec.rb
+++ b/spec/note_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe Amorail::Note do
+  before { mock_api }
+
+  it_behaves_like 'elementable'
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:note_type) }
+    it { is_expected.to validate_presence_of(:text) }
+  end
+
+  describe '.attributes' do
+    subject { described_class.attributes }
+
+    it_behaves_like 'entity_class'
+
+    specify do
+      is_expected.to include(
+        :note_type,
+        :text
+      )
+    end
+  end
+end

--- a/spec/note_spec.rb
+++ b/spec/note_spec.rb
@@ -6,8 +6,9 @@ describe Amorail::Note do
   it_behaves_like 'elementable'
 
   describe 'validations' do
-    it { is_expected.to validate_presence_of(:note_type) }
     it { is_expected.to validate_presence_of(:text) }
+    it { is_expected.to validate_presence_of(:note_type) }
+    it { is_expected.to validate_inclusion_of(:element_type).in_range(1..4) }
   end
 
   describe '.attributes' do
@@ -17,8 +18,8 @@ describe Amorail::Note do
 
     specify do
       is_expected.to include(
-        :note_type,
-        :text
+        :text,
+        :note_type
       )
     end
   end

--- a/spec/support/elementable_example.rb
+++ b/spec/support/elementable_example.rb
@@ -1,0 +1,53 @@
+shared_examples 'elementable' do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:element_id) }
+    it { is_expected.to validate_presence_of(:element_type) }
+    it { is_expected.to validate_inclusion_of(:element_type).in_range(1..3) }
+  end
+
+  describe '.attributes' do
+    subject { described_class.attributes }
+
+    specify do
+      is_expected.to include(
+        :element_type,
+        :element_id
+      )
+    end
+  end
+
+  describe '#params' do
+    subject { elementable.params }
+
+    let(:elementable) do
+      described_class.new(
+        element_id: 1,
+        element_type: 2
+      )
+    end
+
+    it { is_expected.to include(element_id: 1) }
+    it { is_expected.to include(element_type: 2) }
+  end
+
+  describe 'element type behaviour' do
+    let(:elementable) { described_class.new }
+
+    it 'set element_type on initialize' do
+      expect(described_class.new(lead: true).element_type).to eq 2
+      expect(described_class.new(lead: false).element_type).to be_nil
+      expect(described_class.new(contact: true).contact?).to be_truthy
+    end
+
+    it 'set element_type with bang method' do
+      elementable.contact!
+      expect(elementable.element_type).to eq 1
+
+      elementable.lead!
+      expect(elementable.element_type).to eq 2
+
+      elementable.company!
+      expect(elementable.element_type).to eq 3
+    end
+  end
+end

--- a/spec/support/elementable_example.rb
+++ b/spec/support/elementable_example.rb
@@ -2,7 +2,6 @@ shared_examples 'elementable' do
   describe 'validations' do
     it { is_expected.to validate_presence_of(:element_id) }
     it { is_expected.to validate_presence_of(:element_type) }
-    it { is_expected.to validate_inclusion_of(:element_type).in_range(1..3) }
   end
 
   describe '.attributes' do

--- a/spec/task_spec.rb
+++ b/spec/task_spec.rb
@@ -6,9 +6,10 @@ describe Amorail::Task do
   it_behaves_like 'elementable'
 
   describe "validations" do
-    it { should validate_presence_of(:text) }
-    it { should validate_presence_of(:task_type) }
-    it { should validate_presence_of(:complete_till) }
+    it { is_expected.to validate_presence_of(:text) }
+    it { is_expected.to validate_presence_of(:task_type) }
+    it { is_expected.to validate_presence_of(:complete_till) }
+    it { is_expected.to validate_inclusion_of(:element_type).in_range(1..3) }
   end
 
   describe ".attributes" do

--- a/spec/task_spec.rb
+++ b/spec/task_spec.rb
@@ -3,10 +3,9 @@ require "spec_helper"
 describe Amorail::Task do
   before { mock_api }
 
+  it_behaves_like 'elementable'
+
   describe "validations" do
-    it { should validate_presence_of(:element_id) }
-    it { should validate_presence_of(:element_type) }
-    it { should validate_inclusion_of(:element_type).in_range(1..2) }
     it { should validate_presence_of(:text) }
     it { should validate_presence_of(:task_type) }
     it { should validate_presence_of(:complete_till) }
@@ -19,8 +18,6 @@ describe Amorail::Task do
 
     specify do
       is_expected.to include(
-        :element_type,
-        :element_id,
         :text,
         :task_type,
         :complete_till
@@ -28,27 +25,9 @@ describe Amorail::Task do
     end
   end
 
-  describe "contact and lead" do
-    let(:task) { described_class.new }
-    it "set element_type on initialize" do
-      expect(described_class.new(lead: true).element_type).to eq 2
-      expect(described_class.new(contact: true).contact?).to be_truthy
-      expect(described_class.new(lead: false).element_type).to be_nil
-    end
-
-    it "set element_type with bang method" do
-      task.contact!
-      expect(task.element_type).to eq 1
-      task.lead!
-      expect(task.element_type).to eq 2
-    end
-  end
-
   describe "#params" do
     let(:task) do
       described_class.new(
-        element_id: 1,
-        element_type: 1,
         text: 'Win the war',
         task_type: 'test',
         complete_till: '2015-05-09 12:00:00'
@@ -58,8 +37,6 @@ describe Amorail::Task do
     subject { task.params }
 
     specify { is_expected.to include(:last_modified) }
-    specify { is_expected.to include(element_id: 1) }
-    specify { is_expected.to include(element_type: 1) }
     specify { is_expected.to include(text: 'Win the war') }
     specify { is_expected.to include(task_type: 'test') }
     specify {


### PR DESCRIPTION
Hi @palkan,

I would like to implement Note entity.
It behaves very similar to existing Task entity, that is why I decided to extract common functionality to `Elementable` module.

Current API [says](https://developers.amocrm.ru/rest_api/tasks_set.php) that Task's `element_type` can be one of the digits in range of 1-3 (and Note's `element_type` too). So I updated it as well.

P. S.
After submitting PR I noticed that #17 implements Note entity too. I think #17 can be closed now.