### PR TITLE
Fix faraday warning about middleware-adapter order

### DIFF
--- a/lib/amorail/client.rb
+++ b/lib/amorail/client.rb
@@ -15,9 +15,9 @@ module Amorail
       @api_key = api_key
       @usermail = usermail
       @connect = Faraday.new(url: api_endpoint) do |faraday|
-        faraday.adapter Faraday.default_adapter
         faraday.response :json, content_type: /\bjson$/
         faraday.use :instrumentation
+        faraday.adapter Faraday.default_adapter
       end
     end
 


### PR DESCRIPTION
Hi @palkan,
I updated Faraday from 0.12.1 to 0.12.2 and got a warning:
> WARNING: Unexpected middleware set after the adapter. This won't be supported from Faraday 1.0.

It was added in https://github.com/lostisland/faraday/pull/685
According to Faraday's documentation adapter should be the last middleware.

This PR fix the problem.