### PR TITLE
Allow to return value from Amorail.with_client

### DIFF
--- a/lib/amorail.rb
+++ b/lib/amorail.rb
@@ -35,6 +35,7 @@ module Amorail
     client = Client.new(client) unless client.is_a?(Client)
     ClientRegistry.client = client
     yield
+  ensure
     ClientRegistry.client = nil
   end
 


### PR DESCRIPTION
@palkan, I have integration with amoCRM for 2 accounts. 
So I have to use `Amorail.with_client` and pass code as block to the method.
Currently `.with_client` returns `nil`, but I would like it to return result of yielded block instead.

To handle this my proposal is to move `ClientRegistry.client = nil` to `ensure` block which doesn't return a value. Also it would be more safe because `yield` can raise an error if client's code has bugs.

What do you think?