### PR TITLE
Add pipeline_id field to Lead

### DIFF
--- a/lib/amorail/entities/lead.rb
+++ b/lib/amorail/entities/lead.rb
@@ -3,7 +3,7 @@ module Amorail
   class Lead < Amorail::Entity
     amo_names "leads"
 
-    amo_field :name, :price, :status_id, :tags
+    amo_field :name, :price, :status_id, :pipeline_id, :tags
 
     validates :name, :status_id, presence: true
 

--- a/spec/fixtures/leads.json
+++ b/spec/fixtures/leads.json
@@ -6,6 +6,7 @@
     "name":  "Research new technologies",
     "last_modified":  1374656336,
     "status_id":  "7046196",
+    "pipeline_id": 683506,
     "price":  "500000",
     "responsible_user_id":  "103586",
     "tags":[
@@ -37,6 +38,7 @@
     "name":  "Sell it!",
     "last_modified":  1374656336,
     "status_id":  "7046196",
+    "pipeline_id": 683506,
     "price":  "100000",
     "responsible_user_id":  "103586",
     "tags":[

--- a/spec/lead_spec.rb
+++ b/spec/lead_spec.rb
@@ -18,6 +18,7 @@ describe Amorail::Lead do
         :name,
         :price,
         :status_id,
+        :pipeline_id,
         :tags
       )
     end
@@ -29,6 +30,7 @@ describe Amorail::Lead do
         name: 'Test',
         price: 100,
         status_id: 2,
+        pipeline_id: 17,
         tags: 'test lead'
       )
     end
@@ -39,6 +41,7 @@ describe Amorail::Lead do
     specify { is_expected.to include(name: 'Test') }
     specify { is_expected.to include(price: 100) }
     specify { is_expected.to include(status_id: 2) }
+    specify { is_expected.to include(pipeline_id: 17) }
     specify { is_expected.to include(tags: 'test lead') }
   end
 


### PR DESCRIPTION
`pipeline_id` is useful field to avoid a lead to be moved to main pipeline once it done.

I usually define my custom classes for entities like `class Lead < Amorail::Lead` and I found myself adding `amo_field :pipeline_id` all the time.
I guess we can add it to the main class.