### PR TITLE
Update anyway_config to ~>1.0

### DIFF
--- a/amorail.gemspec
+++ b/amorail.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_development_dependency "shoulda-matchers", "~> 2.0"
   spec.add_development_dependency "rubocop", "~> 0.49"
-  spec.add_dependency "anyway_config", "~> 0", ">= 0.3"
+  spec.add_dependency "anyway_config", "~> 1.0"
   spec.add_dependency "faraday"
   spec.add_dependency "faraday_middleware"
   spec.add_dependency 'activemodel'

--- a/lib/amorail.rb
+++ b/lib/amorail.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'amorail/version'
 require 'amorail/config'
 require 'amorail/client'

--- a/lib/amorail/client.rb
+++ b/lib/amorail/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'faraday'
 require 'faraday_middleware'
 require 'json'

--- a/lib/amorail/config.rb
+++ b/lib/amorail/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'anyway'
 
 module Amorail

--- a/lib/amorail/entities/company.rb
+++ b/lib/amorail/entities/company.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'amorail/entities/leadable'
 
 module Amorail

--- a/lib/amorail/entities/contact.rb
+++ b/lib/amorail/entities/contact.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'amorail/entities/leadable'
 
 module Amorail

--- a/lib/amorail/entities/contact_link.rb
+++ b/lib/amorail/entities/contact_link.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Amorail
   # AmoCRM contact-link join model
   class ContactLink < Amorail::Entity

--- a/lib/amorail/entities/elementable.rb
+++ b/lib/amorail/entities/elementable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Amorail
   # Provides common functionallity for entities
   # that can be attached to another objects.
@@ -6,9 +8,9 @@ module Amorail
 
     ELEMENT_TYPES = {
       contact: 1,
-      lead:    2,
+      lead: 2,
       company: 3,
-      task:    4
+      task: 4
     }.freeze
 
     included do

--- a/lib/amorail/entities/lead.rb
+++ b/lib/amorail/entities/lead.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Amorail
   # AmoCRM lead entity
   class Lead < Amorail::Entity

--- a/lib/amorail/entities/leadable.rb
+++ b/lib/amorail/entities/leadable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Amorail
   # Lead associations
   module Leadable

--- a/lib/amorail/entities/note.rb
+++ b/lib/amorail/entities/note.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'amorail/entities/elementable'
 
 module Amorail

--- a/lib/amorail/entities/task.rb
+++ b/lib/amorail/entities/task.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'amorail/entities/elementable'
 
 module Amorail

--- a/lib/amorail/entities/webhook.rb
+++ b/lib/amorail/entities/webhook.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Amorail
   # AmoCRM webhook entity
   class Webhook < Entity

--- a/lib/amorail/entity.rb
+++ b/lib/amorail/entity.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_model'
 
 module Amorail

--- a/lib/amorail/entity/finders.rb
+++ b/lib/amorail/entity/finders.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Amorail # :nodoc: all
   class Entity
     class << self

--- a/lib/amorail/entity/params.rb
+++ b/lib/amorail/entity/params.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/hash/indifferent_access"
 
 module Amorail # :nodoc: all

--- a/lib/amorail/entity/persistence.rb
+++ b/lib/amorail/entity/persistence.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Amorail # :nodoc: all
   class Entity
     class InvalidRecord < ::Amorail::Error; end

--- a/lib/amorail/exceptions.rb
+++ b/lib/amorail/exceptions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Amorail Exceptions.
 # Every class is name of HTTP response error code(status)
 module Amorail

--- a/lib/amorail/property.rb
+++ b/lib/amorail/property.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Amorail
   # Return hash key as method call
   module MethodMissing

--- a/lib/amorail/railtie.rb
+++ b/lib/amorail/railtie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Amorail
   # Add amorail rake tasks
   class Railtie < Rails::Railtie

--- a/lib/amorail/version.rb
+++ b/lib/amorail/version.rb
@@ -1,4 +1,6 @@
+# frozen_string_literal: true
+
 # Amorail version
 module Amorail
-  VERSION = "0.5.0".freeze
+  VERSION = '0.5.0'
 end

--- a/lib/tasks/amorail.rake
+++ b/lib/tasks/amorail.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :amorail do
   desc 'Check Amorail configuration'
   task :check do

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Amorail::Client do

--- a/spec/company_spec.rb
+++ b/spec/company_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Amorail::Company do

--- a/spec/contact_link_spec.rb
+++ b/spec/contact_link_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Amorail::ContactLink do

--- a/spec/contact_spec.rb
+++ b/spec/contact_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Amorail::Contact do

--- a/spec/entity_spec.rb
+++ b/spec/entity_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe MyEntity do

--- a/spec/helpers/webmock_helpers.rb
+++ b/spec/helpers/webmock_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # rubocop: disable Metrics/ModuleLength
 module AmoWebMock
   def mock_api

--- a/spec/lead_spec.rb
+++ b/spec/lead_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Amorail::Lead do

--- a/spec/my_contact_spec.rb
+++ b/spec/my_contact_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe MyContact do

--- a/spec/note_spec.rb
+++ b/spec/note_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Amorail::Note do

--- a/spec/property_spec.rb
+++ b/spec/property_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "webmock/rspec"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 

--- a/spec/support/elementable_example.rb
+++ b/spec/support/elementable_example.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 shared_examples 'elementable' do
   describe 'validations' do
     it { is_expected.to validate_presence_of(:element_id) }

--- a/spec/support/entity_class_example.rb
+++ b/spec/support/entity_class_example.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 shared_examples 'entity_class' do

--- a/spec/support/leadable_example.rb
+++ b/spec/support/leadable_example.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 shared_examples 'leadable' do

--- a/spec/support/my_contact.rb
+++ b/spec/support/my_contact.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class MyContact < Amorail::Contact # :nodoc:
   amo_property :teachbase_id
 end

--- a/spec/support/my_entity.rb
+++ b/spec/support/my_entity.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # We only need this class to set Amo names for core Entity
 class MyEntity < Amorail::Entity # :nodoc:
   amo_names 'entity'

--- a/spec/task_spec.rb
+++ b/spec/task_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Amorail::Task do

--- a/spec/webhook_spec.rb
+++ b/spec/webhook_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Amorail::Webhook do


### PR DESCRIPTION
Current version of the gem conflicts with anycable.
```
Bundler could not find compatible versions for gem "anyway_config":
  In snapshot (Gemfile.lock):
    anyway_config (= 1.4.4)

  In Gemfile:
    amorail was resolved to 0.5.0, which depends on
      anyway_config (~> 0, >= 0.3)

    anycable-rails was resolved to 0.6.4, which depends on
      anycable (~> 0.6.0) was resolved to 0.6.3, which depends on
        anyway_config (~> 1.4.2)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```
@palkan Will this change work?
If everything is ok, could you please release the new version?