### PR TITLE
Add support method_name for amo_property option

### DIFF
--- a/lib/amorail/entity.rb
+++ b/lib/amorail/entity.rb
@@ -100,7 +100,7 @@ module Amorail
 
     def custom_field_name(field)
       fname = field['code'] || field['name']
-      return nil if fname.nil?
+      return if fname.nil?
 
       fname = self.class.properties
                   .fetch(fname.downcase, {})[:method_name] || fname

--- a/lib/amorail/entity.rb
+++ b/lib/amorail/entity.rb
@@ -34,7 +34,7 @@ module Amorail
 
       def amo_property(name, options = {})
         properties[name] = options
-        attr_accessor(name)
+        attr_accessor(options.fetch(:method_name, name))
       end
 
       def attributes
@@ -89,13 +89,22 @@ module Amorail
       return if fields.nil?
 
       fields.each do |f|
-        fname = f['code'] || f['name']
+        fname = custom_field_name(f)
         next if fname.nil?
 
         fname = "#{fname.downcase}="
         fval = f.fetch('values').first.fetch('value')
         send(fname, fval) if respond_to?(fname)
       end
+    end
+
+    def custom_field_name(field)
+      fname = field['code'] || field['name']
+      return nil if fname.nil?
+
+      fname = self.class.properties
+                  .fetch(fname.downcase, {})[:method_name] || fname
+      fname
     end
 
     # call safe method <safe_request>. safe_request call authorize

--- a/lib/amorail/entity/params.rb
+++ b/lib/amorail/entity/params.rb
@@ -22,7 +22,7 @@ module Amorail # :nodoc: all
 
       custom_fields = []
       self.class.properties.each do |k, v|
-        prop_id = props.send(k.downcase).id
+        prop_id = props.send(k).id
         prop_val = { value: send(v.fetch(:method_name, k)) }.merge(v)
         custom_fields << { id: prop_id, values: [prop_val] }
       end

--- a/lib/amorail/entity/params.rb
+++ b/lib/amorail/entity/params.rb
@@ -21,10 +21,9 @@ module Amorail # :nodoc: all
       props = properties.send(self.class.amo_name)
 
       custom_fields = []
-
       self.class.properties.each do |k, v|
-        prop_id = props.send(k).id
-        prop_val = { value: send(k) }.merge(v)
+        prop_id = props.send(k.downcase).id
+        prop_val = { value: send(v.fetch(:method_name, k)) }.merge(v)
         custom_fields << { id: prop_id, values: [prop_val] }
       end
 

--- a/lib/amorail/property.rb
+++ b/lib/amorail/property.rb
@@ -4,19 +4,15 @@ module Amorail
   # Return hash key as method call
   module MethodMissing
     def method_missing(method_sym, *arguments, &block)
-      if data.key?(prep_method_name(method_sym))
-        data.fetch(prep_method_name(method_sym))
+      if data.key?(method_sym.to_s.downcase)
+        data.fetch(method_sym.to_s.downcase)
       else
         super
       end
     end
 
     def respond_to_missing?(method_sym, *args)
-      args.size.zero? && data.key?(prep_method_name(method_sym))
-    end
-
-    def prep_method_name(name_sym)
-      name_sym.to_s.downcase
+      args.size.zero? && data.key?(method_sym.to_s.downcase)
     end
   end
 

--- a/lib/amorail/property.rb
+++ b/lib/amorail/property.rb
@@ -4,15 +4,19 @@ module Amorail
   # Return hash key as method call
   module MethodMissing
     def method_missing(method_sym, *arguments, &block)
-      if data.key?(method_sym.to_s)
-        data.fetch(method_sym.to_s)
+      if data.key?(prep_method_name(method_sym))
+        data.fetch(prep_method_name(method_sym))
       else
         super
       end
     end
 
     def respond_to_missing?(method_sym, *args)
-      args.size.zero? && data.key?(method_sym.to_s)
+      args.size.zero? && data.key?(prep_method_name(method_sym))
+    end
+
+    def prep_method_name(name_sym)
+      name_sym.to_s.downcase
     end
   end
 


### PR DESCRIPTION
Due to issue: https://github.com/teachbase/amorail/issues/39
and thanks to: https://github.com/foxford/amorail/commit/3404da937661230ccc7c9f23f138cdacd65dc477

This will help to do things this way:
```ruby
class MyAmoLead < Amorail::Lead
  amo_property 'REFERER', method_name: :referer
  amo_property 'from_mark', method_name: :mark
end
```

Warning: property in code above is in uppercase. To make this works i added downcase:
```ruby
# lib/amorail/entity/params.rb:25
prop_id = props.send(k.downcase).id
```
I hope this change does not cause problems. Otherwise getting an error:
```bash
NoMethodError: undefined method `REFERER' for #<Amorail::Property::Lead:0x0000555b9dafbdf8>
/app/tmp/amorail/lib/amorail/property.rb:10:in `method_missing'
/app/tmp/amorail/lib/amorail/entity/params.rb:25:in `block in custom_fields'
/app/tmp/amorail/lib/amorail/entity/params.rb:24:in `each'
/app/tmp/amorail/lib/amorail/entity/params.rb:24:in `custom_fields'
/app/tmp/amorail/lib/amorail/entity/params.rb:13:in `params'
/app/tmp/amorail/lib/amorail/entity/params.rb:38:in `create_params'
/app/tmp/amorail/lib/amorail/entity.rb:113:in `push'
/app/tmp/amorail/lib/amorail/entity/persistence.rb:19:in `save'
/app/tmp/amorail/lib/amorail/entity/persistence.rb:23:in `save!'
/app/app/models/lead.rb:31:in `sync_remote'
/app/lib/tasks/amo.rake:15:in `block (2 levels) in <main>'
/bundle/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:54:in `load'
/bundle/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:54:in `load'
-e:1:in `<main>'
```
